### PR TITLE
Update <> triggers to work as expected with ehive v2.7

### DIFF
--- a/cfg/tasks/cppd-1/general-health.yaml
+++ b/cfg/tasks/cppd-1/general-health.yaml
@@ -72,8 +72,12 @@ sections:
             condition:
               - section: substance
                 question: drink_freq
-                operator: <>
-                value: never
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: drink_freq
+                    operator: <>
+                    value: never
       - key: smoke_100
         question: Have you smoked at least 100 cigarettes in your entire life?
         type: YESNO_CHOICE
@@ -97,8 +101,12 @@ sections:
             condition:
               - section: substance
                 question: smoking
-                operator: <>
-                value: no
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: smoking
+                    operator: <>
+                    value: no
       - key: coffee_count
         question: On average, how many cups of coffee do you drink per day?
         type: NUMERIC

--- a/cfg/tasks/cppd-2__case/general-health.yaml
+++ b/cfg/tasks/cppd-2__case/general-health.yaml
@@ -72,8 +72,12 @@ sections:
             condition:
               - section: substance
                 question: drink_freq
-                operator: <>
-                value: never
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: drink_freq
+                    operator: <>
+                    value: never
       - key: smoke_100
         question: Have you smoked at least 100 cigarettes in your entire life?
         type: YESNO_CHOICE
@@ -97,8 +101,12 @@ sections:
             condition:
               - section: substance
                 question: smoking
-                operator: <>
-                value: no
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: smoking
+                    operator: <>
+                    value: no
       - key: coffee_count
         question: On average, how many cups of coffee do you drink per day?
         type: NUMERIC

--- a/cfg/tasks/cppd-2__control/general-health.yaml
+++ b/cfg/tasks/cppd-2__control/general-health.yaml
@@ -72,8 +72,12 @@ sections:
             condition:
               - section: substance
                 question: drink_freq
-                operator: <>
-                value: never
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: drink_freq
+                    operator: <>
+                    value: never
       - key: smoke_100
         question: Have you smoked at least 100 cigarettes in your entire life?
         type: YESNO_CHOICE
@@ -97,8 +101,12 @@ sections:
             condition:
               - section: substance
                 question: smoking
-                operator: <>
-                value: no
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: smoking
+                    operator: <>
+                    value: no
       - key: coffee_count
         question: On average, how many cups of coffee do you drink per day?
         type: NUMERIC

--- a/cfg/tasks/cramp/general-health.yaml
+++ b/cfg/tasks/cramp/general-health.yaml
@@ -86,8 +86,12 @@ sections:
             condition:
               - section: substance
                 question: drink_freq
-                operator: <>
-                value: never
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: drink_freq
+                    operator: <>
+                    value: never
       - key: smoke_100
         question: Have you smoked at least 100 cigarettes in your entire life?
         type: YESNO_CHOICE
@@ -111,8 +115,12 @@ sections:
             condition:
               - section: substance
                 question: smoking
-                operator: <>
-                value: no
+                operator: IS_SET
+                AND:
+                  - section: substance
+                    question: smoking
+                    operator: <>
+                    value: no
       - key: coffee_count
         question: On average, how many cups of coffee do you drink per day?
         type: NUMERIC


### PR DESCRIPTION
ehive 2.7 removes the type equality requirement for <> triggers. Thus we need to add an IS_SET comparison in tandem with the existing <> triggers.